### PR TITLE
Support image icon loading.

### DIFF
--- a/filepicker/build.gradle
+++ b/filepicker/build.gradle
@@ -37,6 +37,10 @@ ext.supportLibVersion = '28.0.0'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    compileOnly 'com.squareup.picasso:picasso:2.5.2'
+    compileOnly ("com.github.bumptech.glide:glide:4.9.0") {
+        exclude group: "com.android.support"
+    }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:recyclerview-v7:${supportLibVersion}"

--- a/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
@@ -72,14 +72,17 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
      * 文件列表适配器
      */
     private var listAdapter: FileListAdapter? = null
+
     /**
      * 导航栏列表适配器
      */
     private var navAdapter: FileNavAdapter? = null
+
     /**
      * 导航栏数据集
      */
     private var navDataSource = ArrayList<FileNavBeanImpl>()
+
     /**
      * 文件夹为空时展示的空视图
      */

--- a/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
@@ -92,7 +92,6 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
     private val fileListListener: RecyclerViewListener by lazy { getListener(rv_list_file_picker) }
     private val navListener: RecyclerViewListener by lazy { getListener(rv_nav_file_picker) }
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(pickerConfig.themeId)
         super.onCreate(savedInstanceState)
@@ -187,7 +186,6 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
                     addRule(RelativeLayout.CENTER_VERTICAL)
                     setMargins(0, 0, ScreenUtils.dipToPx(this@FilePickerActivity, 16f), 0)
                 }
-
             }
             setOnClickListener(this@FilePickerActivity)
             FilePickerManager.config.confirmText.let {
@@ -240,7 +238,6 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
             )
         }
     }
-
 
     private fun initRv(
         listData: ArrayList<FileItemBeanImpl>?,
@@ -427,7 +424,7 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
      * 从导航栏中调用本方法，需要传入 pos，以便生产新的 nav adapter
      */
     private fun enterDirAndUpdateUI(fileBean: FileBean) {
-        //清除当前选中状态
+        // 清除当前选中状态
         cleanStatus()
 
         // 获取文件夹文件
@@ -471,7 +468,6 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
             scheduleLayoutAnimation()
         }
     }
-
 
     private fun switchButton(isEnable: Boolean) {
         btn_confirm_file_picker?.isEnabled = isEnable

--- a/filepicker/src/main/java/me/rosuh/filepicker/adapter/FileListAdapter.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/adapter/FileListAdapter.kt
@@ -99,7 +99,6 @@ class FileListAdapter(
         }
     }
 
-
     override fun getItem(position: Int): FileItemBeanImpl? {
         if (position >= 0 &&
             position < dataList!!.size &&
@@ -141,14 +140,12 @@ class FileListAdapter(
         }
     }
 
-
     fun multipleDisCheck(position: Int) {
         getItem(position)?.let {
             it.setCheck(false)
             notifyItemChanged(position, false)
         }
     }
-
 
     fun singleCheck(position: Int) {
         when (latestChoicePos) {
@@ -231,7 +228,6 @@ class FileListAdapter(
         private var mItemBeanImpl: FileItemBeanImpl? = null
         private var mPosition: Int? = null
 
-
         override fun bind(itemImpl: FileItemBeanImpl, position: Int) {
             mItemBeanImpl = itemImpl
             mPosition = position
@@ -271,7 +267,6 @@ class FileListAdapter(
                 }
             }
         }
-
     }
 
     /**
@@ -291,7 +286,6 @@ class FileListAdapter(
         override fun bind(itemImpl: FileItemBeanImpl, position: Int) {
             mItemBeanImpl = itemImpl
             mPosition = position
-
             mTvFileName.text = itemImpl.fileName
             mCbItem.isChecked = itemImpl.isChecked()
             mCbItem.visibility = View.VISIBLE
@@ -327,11 +321,9 @@ class FileListAdapter(
                 }
             }
         }
-
     }
 
     /*--------------------------ViewHolder End------------------------------*/
-
     companion object {
         const val DEFAULT_FILE_TYPE = 10001
     }

--- a/filepicker/src/main/java/me/rosuh/filepicker/adapter/FileListAdapter.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/adapter/FileListAdapter.kt
@@ -1,14 +1,21 @@
 package me.rosuh.filepicker.adapter
 
+import android.net.Uri
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.*
+import android.widget.CheckBox
+import android.widget.ImageView
+import android.widget.RadioButton
+import android.widget.TextView
 import me.rosuh.filepicker.FilePickerActivity
 import me.rosuh.filepicker.R
 import me.rosuh.filepicker.bean.FileItemBeanImpl
-import me.rosuh.filepicker.config.FilePickerManager.config as config
+import me.rosuh.filepicker.config.FilePickerManager.config
+import me.rosuh.filepicker.engine.ImageLoadController
+import me.rosuh.filepicker.filetype.RasterImageFileType
+import me.rosuh.filepicker.filetype.VideoFileType
 import java.io.File
 
 /**
@@ -18,7 +25,7 @@ import java.io.File
  * 文件列表适配器类
  */
 class FileListAdapter(
-    private val activity: FilePickerActivity,
+    private val context: FilePickerActivity,
     var dataList: ArrayList<FileItemBeanImpl>?,
     private var isSingleChoice: Boolean = config.singleChoice
 ) : BaseAdapter() {
@@ -32,7 +39,7 @@ class FileListAdapter(
         return when (isSingleChoice) {
             true -> {
                 FileListItemSingleChoiceHolder(
-                    LayoutInflater.from(activity).inflate(
+                    LayoutInflater.from(context).inflate(
                         R.layout.item_single_choise_list_file_picker,
                         parent,
                         false
@@ -41,7 +48,7 @@ class FileListAdapter(
             }
             else -> {
                 FileListItemHolder(
-                    LayoutInflater.from(activity).inflate(
+                    LayoutInflater.from(context).inflate(
                         R.layout.item_list_file_picker,
                         parent,
                         false
@@ -242,7 +249,27 @@ class FileListAdapter(
             }
 
             val resId: Int = itemImpl.fileType?.fileIconResId ?: R.drawable.ic_unknown_file_picker
-            mIcon.setImageResource(resId)
+            when (itemImpl.fileType) {
+                is RasterImageFileType -> {
+                    ImageLoadController.load(
+                        context,
+                        mIcon,
+                        Uri.fromFile(File(itemImpl.filePath)),
+                        resId
+                    )
+                }
+                is VideoFileType -> {
+                    ImageLoadController.load(
+                        context,
+                        mIcon,
+                        Uri.fromFile(File(itemImpl.filePath)),
+                        resId
+                    )
+                }
+                else -> {
+                    mIcon.setImageResource(resId)
+                }
+            }
         }
 
     }
@@ -278,7 +305,27 @@ class FileListAdapter(
             }
 
             val resId: Int = itemImpl.fileType?.fileIconResId ?: R.drawable.ic_unknown_file_picker
-            mIcon.setImageResource(resId)
+            when (itemImpl.fileType) {
+                is RasterImageFileType -> {
+                    ImageLoadController.load(
+                        context,
+                        mIcon,
+                        Uri.fromFile(File(itemImpl.filePath)),
+                        resId
+                    )
+                }
+                is VideoFileType -> {
+                    ImageLoadController.load(
+                        context,
+                        mIcon,
+                        Uri.fromFile(File(itemImpl.filePath)),
+                        resId
+                    )
+                }
+                else -> {
+                    mIcon.setImageResource(resId)
+                }
+            }
         }
 
     }

--- a/filepicker/src/main/java/me/rosuh/filepicker/adapter/FileNavAdapter.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/adapter/FileNavAdapter.kt
@@ -14,12 +14,15 @@ import me.rosuh.filepicker.bean.FileNavBeanImpl
  * @author rosu
  * @date 2018/11/21
  */
-class FileNavAdapter(private val activity: FilePickerActivity, var data: MutableList<FileNavBeanImpl>) :
-    BaseAdapter(){
+class FileNavAdapter(
+    private val activity: FilePickerActivity,
+    var data: MutableList<FileNavBeanImpl>
+) :
+    BaseAdapter() {
     private lateinit var recyclerView: RecyclerView
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        if (parent is RecyclerView){
+        if (parent is RecyclerView) {
             recyclerView = parent
         }
         return NavListHolder(activity.layoutInflater, parent)
@@ -37,7 +40,7 @@ class FileNavAdapter(private val activity: FilePickerActivity, var data: Mutable
         (holder as NavListHolder).bind(data[postion], postion)
     }
 
-    override fun getItem(position: Int): FileNavBeanImpl?{
+    override fun getItem(position: Int): FileNavBeanImpl? {
         return if (position >= 0 && position < data.size) {
             data[position]
         } else {
@@ -45,14 +48,14 @@ class FileNavAdapter(private val activity: FilePickerActivity, var data: Mutable
         }
     }
 
-    inner class NavListHolder(inflater: LayoutInflater, val parent: ViewGroup):
-        RecyclerView.ViewHolder(inflater.inflate(R.layout.item_nav_file_picker, parent, false)){
+    inner class NavListHolder(inflater: LayoutInflater, val parent: ViewGroup) :
+        RecyclerView.ViewHolder(inflater.inflate(R.layout.item_nav_file_picker, parent, false)) {
 
         private var mBtnDir: TextView? = null
 
-        private var pos:Int? = null
+        private var pos: Int? = null
 
-        fun bind(item: FileNavBeanImpl?, position:Int) {
+        fun bind(item: FileNavBeanImpl?, position: Int) {
             pos = position
             mBtnDir = itemView.findViewById(R.id.tv_btn_nav_file_picker)
             mBtnDir?.text = item!!.dirName

--- a/filepicker/src/main/java/me/rosuh/filepicker/adapter/RecyclerViewListener.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/adapter/RecyclerViewListener.kt
@@ -24,20 +24,32 @@ class RecyclerViewListener(
 ) :
     RecyclerView.OnItemTouchListener {
 
+    /**
+     * Custom item click listener, receive item event and redispatch
+     */
     interface OnItemClickListener {
 
+        /**
+         * Item click
+         */
         fun onItemClick(
             adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>,
             view: View,
             position: Int
         )
 
+        /**
+         * Item long click
+         */
         fun onItemLongClick(
             adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>,
             view: View,
             position: Int
         )
 
+        /**
+         * Item child click
+         */
         fun onItemChildClick(
             adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>,
             view: View,

--- a/filepicker/src/main/java/me/rosuh/filepicker/adapter/RecyclerViewListener.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/adapter/RecyclerViewListener.kt
@@ -17,20 +17,35 @@ import me.rosuh.filepicker.utils.ScreenUtils
  * OnItemTouchListener 无法轻易实现对子控件点击事件的监听
  *
  */
-class RecyclerViewListener(val activity: Activity, val recyclerView: RecyclerView, val itemClickListener: OnItemClickListener) :
-    RecyclerView.OnItemTouchListener{
+class RecyclerViewListener(
+    val activity: Activity,
+    val recyclerView: RecyclerView,
+    val itemClickListener: OnItemClickListener
+) :
+    RecyclerView.OnItemTouchListener {
 
     interface OnItemClickListener {
 
-        fun onItemClick(adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>, view: View, position: Int)
+        fun onItemClick(
+            adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>,
+            view: View,
+            position: Int
+        )
 
-        fun onItemLongClick(adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>, view: View, position: Int)
+        fun onItemLongClick(
+            adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>,
+            view: View,
+            position: Int
+        )
 
-        fun onItemChildClick(adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>, view: View, position: Int)
+        fun onItemChildClick(
+            adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>,
+            view: View,
+            position: Int
+        )
     }
 
-
-    private var gestureDetectorCompat:GestureDetectorCompat =
+    private var gestureDetectorCompat: GestureDetectorCompat =
         GestureDetectorCompat(recyclerView.context, ItemTouchHelperGestureListener())
 
     override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {
@@ -47,22 +62,33 @@ class RecyclerViewListener(val activity: Activity, val recyclerView: RecyclerVie
     private val iconRight = screenWidth * 0.1370
     private val checkBoxLeft = screenWidth * (1 - 0.1370)
 
-
-    inner class ItemTouchHelperGestureListener:GestureDetector.SimpleOnGestureListener() {
+    inner class ItemTouchHelperGestureListener : GestureDetector.SimpleOnGestureListener() {
         override fun onSingleTapUp(e: MotionEvent?): Boolean {
             val childView = recyclerView.findChildViewUnder(e!!.x, e.y)
-            childView?:return false
-            when(childView.id){
+            childView ?: return false
+            when (childView.id) {
                 R.id.item_list_file_picker -> {
                     // 点击在 icon 上或者点击在 checkbox 上
-                    if (e.x <= iconRight || e.x >= checkBoxLeft){
-                        itemClickListener.onItemChildClick(recyclerView.adapter!!, childView, recyclerView.getChildLayoutPosition(childView))
+                    if (e.x <= iconRight || e.x >= checkBoxLeft) {
+                        itemClickListener.onItemChildClick(
+                            recyclerView.adapter!!,
+                            childView,
+                            recyclerView.getChildLayoutPosition(childView)
+                        )
                         return true
                     }
-                    itemClickListener.onItemClick(recyclerView.adapter!!, childView, recyclerView.getChildLayoutPosition(childView))
+                    itemClickListener.onItemClick(
+                        recyclerView.adapter!!,
+                        childView,
+                        recyclerView.getChildLayoutPosition(childView)
+                    )
                 }
                 R.id.item_nav_file_picker -> {
-                    itemClickListener.onItemClick(recyclerView.adapter!!, childView, recyclerView.getChildLayoutPosition(childView))
+                    itemClickListener.onItemClick(
+                        recyclerView.adapter!!,
+                        childView,
+                        recyclerView.getChildLayoutPosition(childView)
+                    )
                 }
             }
             return true
@@ -70,10 +96,14 @@ class RecyclerViewListener(val activity: Activity, val recyclerView: RecyclerVie
 
         override fun onLongPress(e: MotionEvent?) {
             val childView = recyclerView.findChildViewUnder(e!!.x, e.y)
-            childView?:return
-            when(childView.id){
+            childView ?: return
+            when (childView.id) {
                 R.id.item_list_file_picker -> {
-                    itemClickListener.onItemLongClick(recyclerView.adapter!!, childView, recyclerView.getChildLayoutPosition(childView))
+                    itemClickListener.onItemLongClick(
+                        recyclerView.adapter!!,
+                        childView,
+                        recyclerView.getChildLayoutPosition(childView)
+                    )
                 }
             }
         }

--- a/filepicker/src/main/java/me/rosuh/filepicker/bean/BeanSubscriber.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/bean/BeanSubscriber.kt
@@ -5,5 +5,5 @@ interface BeanSubscriber {
      * Update other ui when item check status changed.
      * 当 item 的选中状态改变时，通知 Activity 界面更新
      */
-    fun updateItemUI(isCheck:Boolean)
+    fun updateItemUI(isCheck: Boolean)
 }

--- a/filepicker/src/main/java/me/rosuh/filepicker/bean/FileBean.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/bean/FileBean.kt
@@ -5,8 +5,8 @@ package me.rosuh.filepicker.bean
  * @author rosu
  * @date 2018/11/21
  */
-interface FileBean{
-    var fileName:String
-    var filePath:String
-    var beanSubscriber:BeanSubscriber
+interface FileBean {
+    var fileName: String
+    var filePath: String
+    var beanSubscriber: BeanSubscriber
 }

--- a/filepicker/src/main/java/me/rosuh/filepicker/bean/FileItemBeanImpl.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/bean/FileItemBeanImpl.kt
@@ -18,20 +18,20 @@ import me.rosuh.filepicker.filetype.FileType
  * @constructor
  */
 class FileItemBeanImpl(
-    override var fileName:String,
-    override var filePath:String,
-    private var isChecked:Boolean,
+    override var fileName: String,
+    override var filePath: String,
+    private var isChecked: Boolean,
     var fileType: FileType?,
-    var isDir:Boolean,
-    var isHide:Boolean,
+    var isDir: Boolean,
+    var isHide: Boolean,
     override var beanSubscriber: BeanSubscriber
-): FileBean{
+) : FileBean {
 
-    fun isChecked():Boolean{
+    fun isChecked(): Boolean {
         return isChecked
     }
 
-    fun setCheck(check:Boolean){
+    fun setCheck(check: Boolean) {
         isChecked = check
         beanSubscriber.updateItemUI(check)
     }

--- a/filepicker/src/main/java/me/rosuh/filepicker/bean/FileNavBeanImpl.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/bean/FileNavBeanImpl.kt
@@ -5,7 +5,7 @@ package me.rosuh.filepicker.bean
  * @author rosu
  * @date 2018/11/21
  */
-class FileNavBeanImpl(val dirName:String, val dirPath:String): FileBean {
+class FileNavBeanImpl(val dirName: String, val dirPath: String) : FileBean {
     override var fileName: String
         get() = dirName
         set(value) {}

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/DefaultFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/DefaultFileType.kt
@@ -8,9 +8,9 @@ import me.rosuh.filepicker.filetype.*
  * @author rosu
  * @date 2018/11/27
  */
-class DefaultFileType: AbstractFileType(){
+class DefaultFileType : AbstractFileType() {
 
-    private val allDefaultFileType:ArrayList<FileType> by lazy {
+    private val allDefaultFileType: ArrayList<FileType> by lazy {
         val fileTypes = ArrayList<FileType>()
         fileTypes.add(AudioFileType())
         fileTypes.add(RasterImageFileType())
@@ -26,8 +26,8 @@ class DefaultFileType: AbstractFileType(){
     }
 
     override fun fillFileType(itemBeanImpl: FileItemBeanImpl): FileItemBeanImpl {
-        for (type in allDefaultFileType){
-            if (type.verify(itemBeanImpl.fileName)){
+        for (type in allDefaultFileType) {
+            if (type.verify(itemBeanImpl.fileName)) {
                 itemBeanImpl.fileType = type
                 break
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/FileItemOnClickListener.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/FileItemOnClickListener.kt
@@ -13,15 +13,18 @@ interface FileItemOnClickListener {
     fun onItemClick(
         itemAdapter: FileListAdapter,
         itemView: View,
-        position: Int)
+        position: Int
+    )
 
     fun onItemChildClick(
         itemAdapter: FileListAdapter,
         itemView: View,
-        position: Int)
+        position: Int
+    )
 
     fun onItemLongClick(
         itemAdapter: FileListAdapter,
         itemView: View,
-        position: Int)
+        position: Int
+    )
 }

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/FilePickerConfig.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/FilePickerConfig.kt
@@ -19,69 +19,69 @@ class FilePickerConfig(private val pickerManager: FilePickerManager) {
      * 是否显示隐藏文件，默认隐藏
      * 以符号 . 开头的文件或文件夹视为隐藏
      */
-    var isShowHiddenFiles = false
+    internal var isShowHiddenFiles = false
     /**
      * 是否显示选中框，默认显示
      */
-    var isShowingCheckBox = true
+    internal var isShowingCheckBox = true
     /**
      * 在选中时是否忽略文件夹
      */
-    var isSkipDir = true
+    internal var isSkipDir = true
     /**
      * 是否是单选
      * 如果是单选，则隐藏顶部【全选/取消全选按钮】
      */
-    var singleChoice = false
+    internal var singleChoice = false
     /**
      * 最大可被选中数量
      */
-    var maxSelectable = Int.MAX_VALUE
+    internal var maxSelectable = Int.MAX_VALUE
     /**
      * 存储类型
      */
-    var mediaStorageName = contextRes.getString(R.string.file_picker_tv_sd_card)
+    internal var mediaStorageName = contextRes.getString(R.string.file_picker_tv_sd_card)
 
     /**
      * 自定义存储类型，根据此返回根目录
      */
     @get:StorageMediaType
     @set:StorageMediaType
-    var mediaStorageType: String = STORAGE_EXTERNAL_STORAGE
+    internal var mediaStorageType: String = STORAGE_EXTERNAL_STORAGE
     /**
      * 自定义根目录路径，需要先设置 [mediaStorageType] 为 [STORAGE_CUSTOM_ROOT_PATH]
      */
-    var customRootPath: String = ""
+    internal var customRootPath: String = ""
     /**
      * 自定义过滤器
      */
-    var selfFilter: AbstractFileFilter? = null
+    internal var selfFilter: AbstractFileFilter? = null
     /**
      * 自定文件类型甄别器和默认类型甄别器
      */
-    var selfFileType: AbstractFileType? = null
-    val defaultFileType: DefaultFileType by lazy { DefaultFileType() }
+    internal var selfFileType: AbstractFileType? = null
+    internal val defaultFileType: DefaultFileType by lazy { DefaultFileType() }
     /**
      * 点击操作接口，采用默认实现
      */
-    var fileItemOnClickListener: FileItemOnClickListener? = null
+    internal var fileItemOnClickListener: FileItemOnClickListener? = null
     /**
      * 主题
      */
-    var themeId: Int = R.style.FilePickerThemeRail
+    internal var themeId: Int = R.style.FilePickerThemeRail
     /**
      * 全选文字，取消全选文字，返回文字，已选择文字，确认按钮，选择限制提示语，空列表提示
      */
-    var selectAllText: String = contextRes.getString(R.string.file_picker_tv_select_all)
+    internal var selectAllText: String = contextRes.getString(R.string.file_picker_tv_select_all)
 
-    var deSelectAllText: String =
+    internal var deSelectAllText: String =
         contextRes.getString(R.string.file_picker_tv_deselect_all)
     @StringRes
-    var hadSelectedText: Int = R.string.file_picker_selected_count
-    var confirmText: String = contextRes.getString(R.string.file_picker_tv_select_done)
+    internal var hadSelectedText: Int = R.string.file_picker_selected_count
+    internal var confirmText: String = contextRes.getString(R.string.file_picker_tv_select_done)
     @StringRes
-    var maxSelectCountTips: Int = R.string.max_select_count_tips
-    var emptyListTips: String = contextRes.getString(R.string.empty_list_tips_file_picker)
+    internal var maxSelectCountTips: Int = R.string.max_select_count_tips
+    internal var emptyListTips: String = contextRes.getString(R.string.empty_list_tips_file_picker)
 
     fun showHiddenFiles(isShow: Boolean): FilePickerConfig {
         isShowHiddenFiles = isShow

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/FilePickerManager.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/FilePickerManager.kt
@@ -47,7 +47,7 @@ object FilePickerManager {
     /**
      * 保存数据@param list List<String>到本类中
      */
-    fun saveData(list: List<String>) {
+    internal fun saveData(list: List<String>) {
         dataList = list
     }
 

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/SimpleItemClickListener.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/SimpleItemClickListener.kt
@@ -4,15 +4,9 @@ import android.view.View
 import me.rosuh.filepicker.adapter.FileListAdapter
 
 open class SimpleItemClickListener : FileItemOnClickListener {
-    override fun onItemClick(itemAdapter: FileListAdapter, itemView: View, position: Int) {
+    override fun onItemClick(itemAdapter: FileListAdapter, itemView: View, position: Int) {}
 
-    }
+    override fun onItemChildClick(itemAdapter: FileListAdapter, itemView: View, position: Int) {}
 
-    override fun onItemChildClick(itemAdapter: FileListAdapter, itemView: View, position: Int) {
-
-    }
-
-    override fun onItemLongClick(itemAdapter: FileListAdapter, itemView: View, position: Int) {
-
-    }
+    override fun onItemLongClick(itemAdapter: FileListAdapter, itemView: View, position: Int) {}
 }

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/GlideEngine.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/GlideEngine.kt
@@ -1,0 +1,44 @@
+package me.rosuh.filepicker.engine
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
+
+class GlideEngine : ImageEngine {
+    override fun loadImage(context: Context?, imageView: ImageView?, uri: Uri?, placeholder: Int) {
+        if (context == null || imageView == null) {
+            return
+        }
+        Glide.with(context)
+            .load(uri)
+            .addListener(object : RequestListener<Drawable> {
+                override fun onLoadFailed(
+                    e: GlideException?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    imageView.setImageResource(placeholder)
+                    return true
+                }
+
+                override fun onResourceReady(
+                    resource: Drawable?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    dataSource: DataSource?,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    return false
+                }
+
+            })
+            .into(imageView)
+    }
+}

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/GlideEngine.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/GlideEngine.kt
@@ -10,6 +10,11 @@ import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
 
+/**
+ * @author rosu
+ * @date 2020-04-15
+ * An [ImageEngine] implementation by using Glide
+ */
 class GlideEngine : ImageEngine {
     override fun loadImage(context: Context?, imageView: ImageView?, uri: Uri?, placeholder: Int) {
         if (context == null || imageView == null) {

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageEngine.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageEngine.kt
@@ -1,0 +1,14 @@
+package me.rosuh.filepicker.engine
+
+import android.content.Context
+import android.net.Uri
+import android.widget.ImageView
+
+interface ImageEngine {
+    fun loadImage(
+        context: Context?,
+        imageView: ImageView?,
+        uri: Uri?,
+        placeholder: Int
+    )
+}

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageEngine.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageEngine.kt
@@ -4,7 +4,21 @@ import android.content.Context
 import android.net.Uri
 import android.widget.ImageView
 
+/**
+ * @author rosu
+ * @date 2020-04-15
+ * 描述图片加载器的接口，以便 Glide、Picasso 或其他加载器使用
+ * Describe the interface of the picture loader for use by Glide, Picasso or other loaders
+ */
 interface ImageEngine {
+    /**
+     * 调用此接口加载图片，一般情况下[uri]参数表示图片的本地路径 path，通过[Uri.parse]得到的值。通常是 file:/// 开头
+     * 如果加载失败，将使用[placeholder]
+     * Call this interface to load the picture. Generally, the [uri] parameter indicates the local
+     * path of the picture, and the value obtained through [Uri.parse].
+     * Usually starts with file:///
+     * If loading fails, [placeholder] will be used
+     */
     fun loadImage(
         context: Context?,
         imageView: ImageView?,

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageLoadController.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageLoadController.kt
@@ -1,0 +1,55 @@
+package me.rosuh.filepicker.engine
+
+import android.content.Context
+import android.net.Uri
+import android.widget.ImageView
+import me.rosuh.filepicker.R
+
+object ImageLoadController {
+    private val enableGlide by lazy {
+        try {
+            Class.forName("com.bumptech.glide.Glide")
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private val enablePicasso by lazy {
+        try {
+            Class.forName("com.squareup.picasso.Picasso")
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private var engine: ImageEngine? = null
+
+    init {
+        engine = when {
+            enableGlide -> {
+                GlideEngine()
+            }
+            enablePicasso -> {
+                PicassoEngine()
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
+    fun load(
+        context: Context,
+        iv: ImageView,
+        uri: Uri,
+        placeholder: Int? = R.drawable.ic_unknown_file_picker
+    ) {
+        if (engine == null) {
+            iv.setImageResource(placeholder ?: R.drawable.ic_unknown_file_picker)
+            return
+        }
+        engine?.loadImage(context, iv, uri, placeholder ?: R.drawable.ic_unknown_file_picker)
+    }
+}

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageLoadController.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/ImageLoadController.kt
@@ -5,12 +5,21 @@ import android.net.Uri
 import android.widget.ImageView
 import me.rosuh.filepicker.R
 
+/**
+ * @author rosu
+ * @date 2020-04-15
+ * 一个全局的图片加载控制类，包含了判断是否存在以及存在哪种图片加载引擎。
+ * A global image loading control class, including determining whether there is and what kind of
+ * image loading engine exists.
+ */
 object ImageLoadController {
     private val enableGlide by lazy {
         try {
             Class.forName("com.bumptech.glide.Glide")
             true
-        } catch (e: Exception) {
+        } catch (e: ClassNotFoundException) {
+            false
+        } catch (e: ExceptionInInitializerError) {
             false
         }
     }
@@ -19,7 +28,9 @@ object ImageLoadController {
         try {
             Class.forName("com.squareup.picasso.Picasso")
             true
-        } catch (e: Exception) {
+        } catch (e: ClassNotFoundException) {
+            false
+        } catch (e: ExceptionInInitializerError) {
             false
         }
     }
@@ -40,6 +51,10 @@ object ImageLoadController {
         }
     }
 
+    /**
+     * 加载图片，如果没有不存在图片加载引擎，那么家使用默认 icon
+     * Load images, if there is no image loading engine, then the default icon is used
+     */
     fun load(
         context: Context,
         iv: ImageView,

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/PicassoEngine.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/PicassoEngine.kt
@@ -1,0 +1,17 @@
+package me.rosuh.filepicker.engine
+
+import android.content.Context
+import android.net.Uri
+import android.widget.ImageView
+import com.squareup.picasso.Picasso
+
+class PicassoEngine : ImageEngine {
+    override fun loadImage(context: Context?, imageView: ImageView?, uri: Uri?, placeholder: Int) {
+        Picasso.with(context)
+            .load(uri)
+            .fit()
+            .centerCrop()
+            .placeholder(placeholder)
+            .into(imageView)
+    }
+}

--- a/filepicker/src/main/java/me/rosuh/filepicker/engine/PicassoEngine.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/engine/PicassoEngine.kt
@@ -5,6 +5,11 @@ import android.net.Uri
 import android.widget.ImageView
 import com.squareup.picasso.Picasso
 
+/**
+ * @author rosu
+ * @date 2020-04-15
+ * An [ImageEngine] implementation by using Picasso
+ */
 class PicassoEngine : ImageEngine {
     override fun loadImage(context: Context?, imageView: ImageView?, uri: Uri?, placeholder: Int) {
         Picasso.with(context)

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/AudioFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/AudioFileType.kt
@@ -20,12 +20,12 @@ class AudioFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
-        return when (suffix){
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
+        return when (suffix) {
             "aif", "iff", "m3u", "m4a", "mid", "mp3", "mpa", "wav", "wma", "ogg", "flac", "ape", "alac" -> {
                 true
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/CompressedFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/CompressedFileType.kt
@@ -21,12 +21,12 @@ class CompressedFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
-        return when (suffix){
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
+        return when (suffix) {
             "zip", "rar", "arj", "tar.gz", "tgz", "gz", "iso", "tbz", "tbz2", "7z" -> {
                 true
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/DataBaseFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/DataBaseFileType.kt
@@ -21,12 +21,12 @@ class DataBaseFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
-        return when (suffix){
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
+        return when (suffix) {
             "accdb", "db", "dbf", "mdb", "pdb", "sql" -> {
                 true
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/DataFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/DataFileType.kt
@@ -25,7 +25,7 @@ class DataFileType : FileType {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
         return when (suffix) {
             "csv", "dat", "ged", "key", "keychain", "pps",
             "ppt", "pptx", "sdf", "tar", "tax2016", "tax2017",

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/ExecutableFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/ExecutableFileType.kt
@@ -20,12 +20,12 @@ class ExecutableFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
-        return when (suffix){
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
+        return when (suffix) {
             "apk", "app", "bat", "cgi", "com", "exe", "gadget", "jar", "wsf" -> {
                 true
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/FileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/FileType.kt
@@ -9,13 +9,14 @@ interface FileType {
     /**
      * 文件类型
      */
-    val fileType:String
+    val fileType: String
 
-    val fileIconResId:Int
+    val fileIconResId: Int
+
     /**
      * 传入文件路径，判断是否为该类型
      * @param fileName String
      * @return Boolean
      */
-    fun verify(fileName:String):Boolean
+    fun verify(fileName: String): Boolean
 }

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/FontFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/FontFileType.kt
@@ -21,12 +21,12 @@ class FontFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
-        return when (suffix){
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
+        return when (suffix) {
             "fnt", "fon", "otf", "ttf" -> {
                 true
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/RasterImageFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/RasterImageFileType.kt
@@ -20,13 +20,13 @@ class RasterImageFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
         val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
-        return when (suffix){
-            "jpeg", "jpg", "bmp", "dds", "gif", "png", "psd", "pspimage", "tga", "thm", "tif", "tiff", "yuv"-> {
+        return when (suffix) {
+            "jpeg", "jpg", "bmp", "dds", "gif", "png", "psd", "pspimage", "tga", "thm", "tif", "tiff", "yuv" -> {
                 true
             }
             else -> {

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/TextFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/TextFileType.kt
@@ -21,12 +21,12 @@ class TextFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
-        return when (suffix){
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
+        return when (suffix) {
             "doc", "docx", "log", "txt", "msg", "odt", "pages", "rtf", "tex", "wpd", "wps" -> {
                 true
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/VideoFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/VideoFileType.kt
@@ -25,11 +25,11 @@ class VideoFileType : FileType {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
         return when (suffix) {
             "mp4", "mkv", "mov", "mpg", "mpeg", "3gp",
             "3gpp", "3g2", "3gpp2", "webm", "ts", "avi",
-            "flv", "swf", "wmv", "vob", "m4v"-> {
+            "flv", "swf", "wmv", "vob", "m4v" -> {
                 true
             }
             else -> {

--- a/filepicker/src/main/java/me/rosuh/filepicker/filetype/WebFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/filetype/WebFileType.kt
@@ -20,14 +20,14 @@ class WebFileType : FileType {
          * 比如 文件名仅为：example_png
          */
         val isHasSuffix = fileName.contains(".")
-        if (!isHasSuffix){
+        if (!isHasSuffix) {
             // 如果没有 . 符号，即是没有文件后缀
             return false
         }
-        val suffix = fileName.substring(fileName.lastIndexOf(".")  + 1)
-        return when (suffix){
+        val suffix = fileName.substring(fileName.lastIndexOf(".") + 1)
+        return when (suffix) {
             "asp", "aspx", "cer", "cfm", "csr", "css",
-            "dcr", "html", "htm", "js", "jsp" , "php",
+            "dcr", "html", "htm", "js", "jsp", "php",
             "rss", "xhtml" -> {
                 true
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/utils/FileUtils.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/utils/FileUtils.kt
@@ -24,7 +24,7 @@ class FileUtils {
          * 根据配置参数获取根目录文件
          * @return File
          */
-        fun getRootFile():File {
+        fun getRootFile(): File {
             return when (FilePickerManager.config.mediaStorageType) {
                 STORAGE_EXTERNAL_STORAGE -> {
                     File(Environment.getExternalStorageDirectory().absoluteFile.toURI())
@@ -45,16 +45,37 @@ class FileUtils {
         /**
          * 获取给定文件对象[rootFile]下的所有文件，生成列表项对象
          */
-        fun produceListDataSource(rootFile: File, beanSubscriber: BeanSubscriber):ArrayList<FileItemBeanImpl>{
+        fun produceListDataSource(
+            rootFile: File,
+            beanSubscriber: BeanSubscriber
+        ): ArrayList<FileItemBeanImpl> {
             val listData: ArrayList<FileItemBeanImpl> = ArrayList()
             for (file in rootFile.listFiles()) {
                 //以符号 . 开头的视为隐藏文件或隐藏文件夹，后面进行过滤
                 val isHiddenFile = file.name.startsWith(".")
                 if (file.isDirectory) {
-                    listData.add(FileItemBeanImpl(file.name, file.path, false, null, true, isHiddenFile, beanSubscriber))
+                    listData.add(
+                        FileItemBeanImpl(
+                            file.name,
+                            file.path,
+                            false,
+                            null,
+                            true,
+                            isHiddenFile,
+                            beanSubscriber
+                        )
+                    )
                     continue
                 }
-                val itemBean = FileItemBeanImpl(file.name, file.path, false, null, false, isHiddenFile, beanSubscriber)
+                val itemBean = FileItemBeanImpl(
+                    file.name,
+                    file.path,
+                    false,
+                    null,
+                    false,
+                    isHiddenFile,
+                    beanSubscriber
+                )
                 // 如果调用者没有实现文件类型甄别器，则使用的默认甄别器
                 FilePickerManager.config.selfFileType?.fillFileType(itemBean)
                     ?: FilePickerManager.config.defaultFileType.fillFileType(itemBean)
@@ -64,7 +85,7 @@ class FileUtils {
                 // 隐藏文件处理
                 this.hideFiles<FileItemBeanImpl>(!FilePickerManager.config.isShowHiddenFiles)
                 // 排序
-                this.sortWith(compareBy({!it.isDir}, {it.fileName.toUpperCase()}))
+                this.sortWith(compareBy({ !it.isDir }, { it.fileName.toUpperCase() }))
             }
             // 将当前列表数据暴露，以供调用者自己处理数据
             return FilePickerManager.config.selfFilter?.doFilter(listData) ?: listData
@@ -113,7 +134,12 @@ class FileUtils {
                 // 将列表截取至目标路径元素
                 val isBackToAbove = nextPath == data.dirPath
                 if (isBackToAbove) {
-                    return ArrayList(currentDataSource.subList(0, currentDataSource.indexOf(data) + 1))
+                    return ArrayList(
+                        currentDataSource.subList(
+                            0,
+                            currentDataSource.indexOf(data) + 1
+                        )
+                    )
                 }
             }
             // 循环到此，意味着将是进入子目录

--- a/filepicker/src/main/java/me/rosuh/filepicker/widget/PosLinearLayoutManager.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/widget/PosLinearLayoutManager.kt
@@ -14,7 +14,12 @@ class PosLinearLayoutManager : LinearLayoutManager {
         reverseLayout
     )
 
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(
+    constructor(
+        context: Context?,
+        attrs: AttributeSet?,
+        defStyleAttr: Int,
+        defStyleRes: Int
+    ) : super(
         context,
         attrs,
         defStyleAttr,
@@ -26,7 +31,7 @@ class PosLinearLayoutManager : LinearLayoutManager {
     private var pendingPosOffset = -1
 
     override fun onLayoutChildren(recycler: RecyclerView.Recycler?, state: RecyclerView.State?) {
-        if (pendingTargetPos != -1 && state?.itemCount?:0 > 0){
+        if (pendingTargetPos != -1 && state?.itemCount ?: 0 > 0) {
             scrollToPositionWithOffset(pendingTargetPos, pendingPosOffset)
             pendingPosOffset = -1
             pendingTargetPos = -1
@@ -40,7 +45,7 @@ class PosLinearLayoutManager : LinearLayoutManager {
         super.onRestoreInstanceState(state)
     }
 
-    fun setTargetPos(pos:Int, offset:Int){
+    fun setTargetPos(pos: Int, offset: Int) {
         pendingTargetPos = pos
         pendingPosOffset = offset
     }

--- a/filepicker/src/main/java/me/rosuh/filepicker/widget/RecyclerViewFilePicker.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/widget/RecyclerViewFilePicker.kt
@@ -9,7 +9,11 @@ import android.view.ViewGroup
 class RecyclerViewFilePicker : RecyclerView {
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
+    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(
+        context,
+        attrs,
+        defStyle
+    )
 
     var emptyView: View? = null
         set(value) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -29,7 +29,11 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     debugImplementation project(':filepicker')
-    releaseImplementation 'me.rosuh:AndroidFilePicker:0.6.0'
+//    implementation ("com.github.bumptech.glide:glide:4.8.0") {
+//        exclude group: "com.android.support"
+//    }
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+//    releaseImplementation 'me.rosuh:AndroidFilePicker:0.6.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'


### PR DESCRIPTION
## 1. Support image loading as icons
Load image as icons has been supported, finally, by using `complieOnly` for `Glide` and `Picasso`. If you have `Glide` or `Picasso` already, you don't need to do anything. Otherwise, you don't have `Glide` or `Picasso`, this lib would using default icon, as usual.

## 2. Modify visibility for some internal properties and methods
Just make the interface more organized. All hidden properties and methods are useless for the caller. You would not see them in your code. (You can PR or make an issue if you really want it)

---
## 1. 支持加载图片作为 icon
通过使用`complieOnly`把`Glide` 和 `Picasso` 关联到了本库中。如果您已经拥有了二者其一，那么您不需要做什么额外的工作。如果您两者都没有，那么本库会使用默认的图标显示，就像之前的行为一样。

## 2. 修改了部分属性和方法的可见性
只是为了让接口更加整洁。所以被隐藏起来的属性和方法对调用者几乎是没有作用的。你将再不会在你的代码中看到他们。（你可以发起 PR 或者提交一个 issues，如果你真的需要某些属性的话）。 