### PR TITLE
0.6.3

### DIFF
--- a/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
@@ -216,6 +216,7 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
 
         swipe_refresh_layout?.apply {
             setOnRefreshListener {
+                resetViewState()
                 loadList()
             }
             isRefreshing = true
@@ -441,7 +442,7 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
      */
     private fun enterDirAndUpdateUI(fileBean: FileBean) {
         // 清除当前选中状态
-        cleanStatus()
+        resetViewState()
 
         // 获取文件夹文件
         val nextFiles = File(fileBean.filePath)
@@ -490,7 +491,7 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
         btn_selected_all_file_picker?.isEnabled = isEnable
     }
 
-    private fun cleanStatus() {
+    private fun resetViewState() {
         selectedCount = 1
         updateItemUI(false)
     }

--- a/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/FilePickerActivity.kt
@@ -52,7 +52,7 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
         1,       // Initial pool size
         1,       // Max pool size
         KEEP_ALIVE_TIME,
-        TimeUnit.SECONDS,
+        TimeUnit.MINUTES,
         loadingFileWorkerQueue
     )
         get() {
@@ -61,7 +61,7 @@ class FilePickerActivity : AppCompatActivity(), View.OnClickListener,
                     1,
                     1,
                     KEEP_ALIVE_TIME,
-                    TimeUnit.SECONDS,
+                    TimeUnit.MINUTES,
                     loadingFileWorkerQueue
                 )
             }

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/AbstractFileDetector.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/AbstractFileDetector.kt
@@ -1,0 +1,25 @@
+package me.rosuh.filepicker.config
+
+import me.rosuh.filepicker.bean.FileItemBeanImpl
+import me.rosuh.filepicker.filetype.FileType
+
+/**
+ *
+ * @author rosu
+ * @date 2020/06/25
+ * 这个类用于注册你自己的文件类型检测方法。您需要遵循下列步骤：
+ * 1. 实现您自己的文件类型[FileType]，也就是其中的[FileType.verify]方法
+ * 2. 构建此类的一个子类，并在[AbstractFileDetector.fillFileType] 中，检测文件类型，并赋值给[FileItemBeanImpl.fileType]属性
+ * ===================================================================================================================
+ * This class is used to register your own file type detection methods. You need to follow the following steps:
+ * 1. implement your own file type [FileType], which is the [FileType.verify] method of the [FileType].
+ * 2. Construct a subclass of this class and, in [AbstractFileDetector.fillFileType], detect the file type and assign it to [FileItemBeanImpl.fileType] property.
+ *
+ */
+abstract class AbstractFileDetector {
+    /**
+     * 自定义文件类型识别方法，传入 @param itemBeanImpl 条目数据对象，
+     * 由实现者来实现文件类型的甄别，返回填充了 fileType 的方法
+     */
+    abstract fun fillFileType(itemBeanImpl: FileItemBeanImpl): FileItemBeanImpl
+}

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/AbstractFileType.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/AbstractFileType.kt
@@ -7,6 +7,10 @@ import me.rosuh.filepicker.bean.FileItemBeanImpl
  * @author rosu
  * @date 2018/11/27
  */
+@Deprecated(
+    "Because the class name was confused.",
+    ReplaceWith("AbstractFileDetector", "me.rosuh.filepicker.config")
+)
 abstract class AbstractFileType {
     /**
      * 自定义文件类型识别方法，传入 @param itemBeanImpl 条目数据对象，

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/DefaultFileDetector.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/DefaultFileDetector.kt
@@ -8,7 +8,7 @@ import me.rosuh.filepicker.filetype.*
  * @author rosu
  * @date 2018/11/27
  */
-class DefaultFileType : AbstractFileType() {
+class DefaultFileDetector : AbstractFileDetector() {
 
     private val allDefaultFileType: ArrayList<FileType> by lazy {
         val fileTypes = ArrayList<FileType>()

--- a/filepicker/src/main/java/me/rosuh/filepicker/config/FilePickerConfig.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/config/FilePickerConfig.kt
@@ -19,69 +19,98 @@ class FilePickerConfig(private val pickerManager: FilePickerManager) {
      * 是否显示隐藏文件，默认隐藏
      * 以符号 . 开头的文件或文件夹视为隐藏
      */
-    internal var isShowHiddenFiles = false
+    var isShowHiddenFiles = false
+        private set
+
     /**
      * 是否显示选中框，默认显示
      */
-    internal var isShowingCheckBox = true
+    var isShowingCheckBox = true
+        private set
+
     /**
      * 在选中时是否忽略文件夹
      */
-    internal var isSkipDir = true
+    var isSkipDir = true
+        private set
+
     /**
      * 是否是单选
      * 如果是单选，则隐藏顶部【全选/取消全选按钮】
      */
-    internal var singleChoice = false
+    var singleChoice = false
+        private set
+
     /**
      * 最大可被选中数量
      */
-    internal var maxSelectable = Int.MAX_VALUE
+    var maxSelectable = Int.MAX_VALUE
+        private set
+
     /**
      * 存储类型
      */
-    internal var mediaStorageName = contextRes.getString(R.string.file_picker_tv_sd_card)
+    var mediaStorageName = contextRes.getString(R.string.file_picker_tv_sd_card)
+        private set
 
     /**
      * 自定义存储类型，根据此返回根目录
      */
     @get:StorageMediaType
     @set:StorageMediaType
-    internal var mediaStorageType: String = STORAGE_EXTERNAL_STORAGE
+    var mediaStorageType: String = STORAGE_EXTERNAL_STORAGE
+        private set
+
     /**
      * 自定义根目录路径，需要先设置 [mediaStorageType] 为 [STORAGE_CUSTOM_ROOT_PATH]
      */
-    internal var customRootPath: String = ""
+    var customRootPath: String = ""
+        private set
+
     /**
      * 自定义过滤器
      */
-    internal var selfFilter: AbstractFileFilter? = null
+    var selfFilter: AbstractFileFilter? = null
+        private set
+
     /**
      * 自定文件类型甄别器和默认类型甄别器
      */
-    internal var selfFileType: AbstractFileType? = null
-    internal val defaultFileType: DefaultFileType by lazy { DefaultFileType() }
+    var customDetector: AbstractFileDetector? = null
+        private set
+    val defaultFileDetector: DefaultFileDetector by lazy { DefaultFileDetector() }
+
     /**
      * 点击操作接口，采用默认实现
      */
-    internal var fileItemOnClickListener: FileItemOnClickListener? = null
+    var fileItemOnClickListener: FileItemOnClickListener? = null
+        private set
+
     /**
      * 主题
      */
-    internal var themeId: Int = R.style.FilePickerThemeRail
+    var themeId: Int = R.style.FilePickerThemeRail
+        private set
+
     /**
      * 全选文字，取消全选文字，返回文字，已选择文字，确认按钮，选择限制提示语，空列表提示
      */
-    internal var selectAllText: String = contextRes.getString(R.string.file_picker_tv_select_all)
+    var selectAllText: String = contextRes.getString(R.string.file_picker_tv_select_all)
+        private set
+    var deSelectAllText: String = contextRes.getString(R.string.file_picker_tv_deselect_all)
+        private set
 
-    internal var deSelectAllText: String =
-        contextRes.getString(R.string.file_picker_tv_deselect_all)
     @StringRes
-    internal var hadSelectedText: Int = R.string.file_picker_selected_count
-    internal var confirmText: String = contextRes.getString(R.string.file_picker_tv_select_done)
+    var hadSelectedText: Int = R.string.file_picker_selected_count
+        private set
+    var confirmText: String = contextRes.getString(R.string.file_picker_tv_select_done)
+        private set
+
     @StringRes
-    internal var maxSelectCountTips: Int = R.string.max_select_count_tips
-    internal var emptyListTips: String = contextRes.getString(R.string.empty_list_tips_file_picker)
+    var maxSelectCountTips: Int = R.string.max_select_count_tips
+        private set
+    var emptyListTips: String = contextRes.getString(R.string.empty_list_tips_file_picker)
+        private set
 
     fun showHiddenFiles(isShow: Boolean): FilePickerConfig {
         isShowHiddenFiles = isShow
@@ -120,8 +149,12 @@ class FilePickerConfig(private val pickerManager: FilePickerManager) {
         return this
     }
 
-    fun fileType(fileType: AbstractFileType): FilePickerConfig {
-        selfFileType = fileType
+    /**
+     * 实现 [AbstractFileDetector] 以自定义您自己的文件类型检测器
+     * Custom your file detector by implementing [AbstractFileDetector]
+     */
+    fun customDetector(detector: AbstractFileDetector): FilePickerConfig {
+        customDetector = detector
         return this
     }
 

--- a/filepicker/src/main/java/me/rosuh/filepicker/utils/FileUtils.kt
+++ b/filepicker/src/main/java/me/rosuh/filepicker/utils/FileUtils.kt
@@ -77,8 +77,8 @@ class FileUtils {
                     beanSubscriber
                 )
                 // 如果调用者没有实现文件类型甄别器，则使用的默认甄别器
-                FilePickerManager.config.selfFileType?.fillFileType(itemBean)
-                    ?: FilePickerManager.config.defaultFileType.fillFileType(itemBean)
+                FilePickerManager.config.customDetector?.fillFileType(itemBean)
+                    ?: FilePickerManager.config.defaultFileDetector.fillFileType(itemBean)
                 listData.add(itemBean)
             }
             listData.run {

--- a/filepicker/src/main/res/values-v21/styles.xml
+++ b/filepicker/src/main/res/values-v21/styles.xml
@@ -7,8 +7,6 @@
         <item name="android:buttonStyle">@style/FilePickerThemeRailButtonStyle</item>
         <item name="android:textColor">@color/rail_text_color</item>
         <item name="android:textColorPrimary">@color/rail_textColor_Primary</item>
-        <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
     </style>
 
     <style name="FilePickerThemeRailButtonStyle" parent="Widget.AppCompat.Button.Borderless">
@@ -23,9 +21,6 @@
         <item name="android:buttonStyle">@style/FilePickerThemeReplyButtonStyle</item>
         <item name="android:textColor">@color/reply_text_color</item>
         <item name="android:textColorPrimary">@color/reply_textColor_Primary</item>
-        <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
-
     </style>
 
     <style name="FilePickerThemeReplyButtonStyle" parent="Widget.AppCompat.Button.Borderless">
@@ -40,9 +35,6 @@
         <item name="android:buttonStyle">@style/FilePickerThemeCraneButtonStyle</item>
         <item name="android:textColor">@color/crane_text_color</item>
         <item name="android:textColorPrimary">@color/crane_textColor_Primary</item>
-        <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
-
     </style>
 
     <style name="FilePickerThemeCraneButtonStyle" parent="Widget.AppCompat.Button.Borderless">
@@ -57,8 +49,6 @@
         <item name="android:buttonStyle">@style/FilePickerThemeShrineButtonStyle</item>
         <item name="android:textColor">@color/shrine_text_color</item>
         <item name="android:textColorPrimary">@color/shrine_textColor_Primary</item>
-        <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
     </style>
 
     <style name="FilePickerThemeShrineButtonStyle" parent="Widget.AppCompat.Button.Borderless">

--- a/filepicker/src/main/res/values-zh-rCN/strings.xml
+++ b/filepicker/src/main/res/values-zh-rCN/strings.xml
@@ -11,5 +11,6 @@
     <string name="too_many_files_tips">当前文件过多\n正在载入中&#8230;</string>
     <string name="max_select_count_tips">最多只能选择 %d 项</string>
     <string name="empty_list_tips_file_picker">空空如也~</string>
+    <string name="custom_file_type">自定义文件类型</string>
 
 </resources>

--- a/filepicker/src/main/res/values-zh-rHK/strings.xml
+++ b/filepicker/src/main/res/values-zh-rHK/strings.xml
@@ -11,5 +11,6 @@
     <string name="too_many_files_tips">檔案太多\n載入中&#8230;</string>
     <string name="max_select_count_tips">最多隻能選擇 %d 项</string>
     <string name="empty_list_tips_file_picker">空空如也~</string>
+    <string name="custom_file_type">自定義文件類型</string>
 
 </resources>

--- a/filepicker/src/main/res/values-zh-rTW/strings.xml
+++ b/filepicker/src/main/res/values-zh-rTW/strings.xml
@@ -11,5 +11,6 @@
     <string name="too_many_files_tips">檔案太多\n載入中&#8230;</string>
     <string name="max_select_count_tips">最多隻能選擇 %d 项</string>
     <string name="empty_list_tips_file_picker">空空如也~</string>
+    <string name="custom_file_type">自定義文件類型</string>
 
 </resources>

--- a/filepicker/src/main/res/values-zh/strings.xml
+++ b/filepicker/src/main/res/values-zh/strings.xml
@@ -11,5 +11,6 @@
     <string name="too_many_files_tips">当前文件过多\n正在载入中&#8230;</string>
     <string name="max_select_count_tips">最多只能选择 %d 项</string>
     <string name="empty_list_tips_file_picker">空空如也~</string>
+    <string name="custom_file_type">自定义文件类型</string>
 
 </resources>

--- a/filepicker/src/main/res/values/strings.xml
+++ b/filepicker/src/main/res/values/strings.xml
@@ -10,5 +10,6 @@
     <string name="too_many_files_tips">Too many current files, loading…</string>
     <string name="max_select_count_tips">You can only choose %d items.</string>
     <string name="empty_list_tips_file_picker">Nothing Here~</string>
+    <string name="custom_file_type">Custom file type</string>
 
 </resources>

--- a/filepicker/src/main/res/values/styles.xml
+++ b/filepicker/src/main/res/values/styles.xml
@@ -6,8 +6,6 @@
         <item name="colorAccent">@color/rail_color_accent</item>
         <item name="android:textColor">@color/rail_text_color</item>
         <item name="android:textColorPrimary">@color/rail_textColor_Primary</item>
-        <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
         <item name="buttonStyle">@style/FilePickerThemeRailButtonStyle</item>
     </style>
 
@@ -24,9 +22,6 @@
         <item name="android:textColor">@color/reply_text_color</item>
         <item name="android:textColorPrimary">@color/reply_textColor_Primary</item>
         <item name="buttonStyle">@style/FilePickerThemeReplyButtonStyle</item>
-        <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
-
     </style>
 
     <style name="FilePickerThemeReplyButtonStyle" parent="Widget.AppCompat.Button.Borderless">
@@ -41,9 +36,6 @@
         <item name="buttonStyle">@style/FilePickerThemeCraneButtonStyle</item>
         <item name="android:textColor">@color/crane_text_color</item>
         <item name="android:textColorPrimary">@color/crane_textColor_Primary</item>
-        <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
-
     </style>
 
     <style name="FilePickerThemeCraneButtonStyle" parent="Widget.AppCompat.Button.Borderless">
@@ -58,7 +50,6 @@
         <item name="android:textColor">@color/shrine_text_color</item>
         <item name="android:textColorPrimary">@color/shrine_textColor_Primary</item>
         <!--<item name="android:windowTranslucentStatus">true</item>-->
-        <item name="android:fitsSystemWindows">true</item>
     </style>
 
     <style name="FilePickerThemeShrineButtonStyle" parent="Widget.AppCompat.Button.Borderless">

--- a/sample/src/main/res/layout/demo_activity_main.xml
+++ b/sample/src/main/res/layout/demo_activity_main.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/ns_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.constraint.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -102,6 +103,14 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tv_title_filter" />
 
+        <Button
+            android:id="@+id/btn_custom_file_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_file_type"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/guideline2"
+            app:layout_constraintTop_toTopOf="@+id/btn_only_image" />
 
         <Button
             android:id="@+id/btn_only_dir"

--- a/sample/src/main/res/values-zh/strings.xml
+++ b/sample/src/main/res/values-zh/strings.xml
@@ -12,4 +12,5 @@
     <string name="multi_select">多选文件</string>
     <string name="single_folder">单选文件夹</string>
     <string name="multi_folder">多选文件夹</string>
+    <string name="custom_file_type">自定义文件类型</string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="single_choice">single select</string>
     <string name="only_show_folder">only show folders</string>
     <string name="only_show_imgs">only show images</string>
+    <string name="custom_file_type">custom file type</string>
     <string name="custom_root_path">custom root path</string>
     <string name="show_hidden_files">show hidden files</string>
     <string name="single_select_file">single select files</string>


### PR DESCRIPTION
## 破坏性更新
- `AbstractFileType` 重命名为 `AbstractFileDetector`
    - 仅重命名
- `AbstractFileType` 被弃用，请使用 `AbstractFileDetector`：
    - 因为前者的名字带有误导性
    - 仅作名字变更，其他包括内部接口没有变动，可以直接替换
- `FilePickerConfig#fileType()` 被移除，请使用 `FilePickerConfig#customDetector`
    - 因为前者的名字带有误导性
## 内部更新
- 使用线程池方式进行列表加载的复用
- 调整 `FilePickerActivity` 的部分逻辑
- 调整 `FilePickerConfig` 部分属性和方法的可见性，防止污染 Java 调用 https://github.com/rosuH/AndroidFilePicker/issues/73
- 移除 `fitSystemWindows` 属性，防止某些情况下覆盖状态栏 https://github.com/rosuH/AndroidFilePicker/issues/71
## 新增
- 新增了自定义文件类型的示例 https://github.com/rosuH/AndroidFilePicker/issues/73

---

## Breaking changes
- `AbstractFileType` renamed to ` AbstractFileDetector`: Rename Only
- `AbstractFileType` is deprecated, use `AbstractFileDetector`.
    - Because the former's name is misleading.
    - The only name change, no other changes including internal interface, can be replaced directly.
- `FilePickerConfig#fileType()` is removed and using `FilePickerConfig#customDetector` please.
    - Because the former's name is misleading.
## Internal updates
- Multiplexing of list loads using thread pooling
- Adjust some of the logic of `FilePickerActivity`.
- Adjust the visibility of some properties and methods of `FilePickerConfig` to prevent contamination of Java calls
- Remove the `fitSystemWindows` attribute to prevent overriding the status bar in some cases 
## News
- Example of a custom file type has been added https://github.com/rosuH/AndroidFilePicker/issues/74